### PR TITLE
Fix reader -> member issue in secureDB.

### DIFF
--- a/src/Database/CouchDB/Conduit/DB.hs
+++ b/src/Database/CouchDB/Conduit/DB.hs
@@ -63,10 +63,10 @@ couchSecureDB :: MonadCouch m =>
        Path             -- ^ Database
     -> [B.ByteString]   -- ^ Admin roles 
     -> [B.ByteString]   -- ^ Admin names
-    -> [B.ByteString]   -- ^ Readers roles 
-    -> [B.ByteString]   -- ^ Readers names
+    -> [B.ByteString]   -- ^ Members roles 
+    -> [B.ByteString]   -- ^ Members names
     -> m ()       
-couchSecureDB db adminRoles adminNames readersRoles readersNames = 
+couchSecureDB db adminRoles adminNames membersRoles membersNames = 
     void $ couch HT.methodPut 
             (mkPath [db, "_security"]) [] []
             reqBody protect' 
@@ -74,8 +74,8 @@ couchSecureDB db adminRoles adminNames readersRoles readersNames =
     reqBody = H.RequestBodyLBS $ A.encode $ A.object [
             "admins" A..= A.object [ "roles" A..= adminRoles,
                                      "names" A..= adminNames ],
-            "readers" A..= A.object [ "roles" A..= readersRoles,
-                                     "names" A..= readersNames ] ]
+            "members" A..= A.object [ "roles" A..= membersRoles,
+                                     "names" A..= membersNames ] ]
 
 -- | Database replication. 
 --


### PR DESCRIPTION
I believe the name of the parameters for the _security database is incorrect.

According to the documentation at [The Apache Site](http://wiki.apache.org/couchdb/Security_Features_Overview#Authorization), the names of the top-level entries should be 'admins' and 'members', not 'admins' and 'readers'.

I hope to try and actually create a test for this in the next couple of days, but please don't hold me to that.
